### PR TITLE
Add Admin Account Interface

### DIFF
--- a/BistroQ.Domain/Contracts/Services/Data/IAccountDataService.cs
+++ b/BistroQ.Domain/Contracts/Services/Data/IAccountDataService.cs
@@ -1,0 +1,12 @@
+﻿using BistroQ.Domain.Dtos;
+using BistroQ.Domain.Dtos.Account;
+using BistroQ.Domain.Models.Entities;
+
+public interface IAccountDataService
+{
+    Task<ApiCollectionResponse<IEnumerable<Account>>> GetGridDataAsync(AccountCollectionQueryParams query);
+    Task<Account> GetAccountByIdAsync(string userId);
+    Task<Account> CreateAccountAsync(CreateAccountRequest request);
+    Task<Account> UpdateAccountAsync(string userId, UpdateAccountRequest request);
+    Task<bool> DeleteAccountAsync(string userId);
+}

--- a/BistroQ.Domain/Dtos/Account/AccountCollectionQueryParams.cs
+++ b/BistroQ.Domain/Dtos/Account/AccountCollectionQueryParams.cs
@@ -1,0 +1,7 @@
+﻿namespace BistroQ.Domain.Dtos.Account;
+
+public class AccountCollectionQueryParams : BaseCollectionQueryParams
+{
+    public string? Username { get; set; }
+    public string? Role { get; set; }
+}

--- a/BistroQ.Domain/Dtos/Account/AccountResponse.cs
+++ b/BistroQ.Domain/Dtos/Account/AccountResponse.cs
@@ -1,0 +1,18 @@
+﻿namespace BistroQ.Domain.Dtos.Account;
+
+public class AccountResponse
+{
+    public string Id { get; set; }
+
+    public string Username { get; set; }
+
+    public string Role { get; set; }
+
+    public int? ZoneId { get; set; }
+
+    public int? TableId { get; set; }
+
+    public int? TableNumber { get; set; }
+
+    public string? ZoneName { get; set; }
+}

--- a/BistroQ.Domain/Dtos/Account/AccountResponse.cs
+++ b/BistroQ.Domain/Dtos/Account/AccountResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace BistroQ.Domain.Dtos.Account;
+﻿using BistroQ.Domain.Dtos.Tables;
+
+namespace BistroQ.Domain.Dtos.Account;
 
 public class AccountResponse
 {
@@ -8,11 +10,5 @@ public class AccountResponse
 
     public string Role { get; set; }
 
-    public int? ZoneId { get; set; }
-
-    public int? TableId { get; set; }
-
-    public int? TableNumber { get; set; }
-
-    public string? ZoneName { get; set; }
+    public TableResponse? Table { get; set; }
 }

--- a/BistroQ.Domain/Dtos/Account/CreateAccountRequest.cs
+++ b/BistroQ.Domain/Dtos/Account/CreateAccountRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace BistroQ.Domain.Dtos.Account;
+
+public class CreateAccountRequest
+{
+    public string Username { get; set; }
+    public string Password { get; set; }
+    public string Role { get; set; }
+    public int? TableId { get; set; }
+}

--- a/BistroQ.Domain/Dtos/Account/UpdateAccountRequest.cs
+++ b/BistroQ.Domain/Dtos/Account/UpdateAccountRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace BistroQ.Domain.Dtos.Account;
+
+public class UpdateAccountRequest
+{
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+    public string? Role { get; set; }
+    public int? TableId { get; set; }
+}

--- a/BistroQ.Domain/Models/Entities/Account.cs
+++ b/BistroQ.Domain/Models/Entities/Account.cs
@@ -1,0 +1,14 @@
+﻿namespace BistroQ.Domain.Models.Entities;
+
+public class Account
+{
+    public string Id { get; set; }
+
+    public string Username { get; set; }
+
+    public string Role { get; set; }
+
+    public int? TableId { get; set; }
+
+    public Table Table { get; set; }
+}

--- a/BistroQ.Domain/Models/Entities/Account.cs
+++ b/BistroQ.Domain/Models/Entities/Account.cs
@@ -10,5 +10,5 @@ public class Account
 
     public int? TableId { get; set; }
 
-    public Table Table { get; set; }
+    public Table? Table { get; set; }
 }

--- a/BistroQ.Domain/Models/Entities/Table.cs
+++ b/BistroQ.Domain/Models/Entities/Table.cs
@@ -2,8 +2,6 @@
 {
     public int? TableId { get; set; }
 
-    public string? Name { get; set; }
-
     public int? ZoneId { get; set; }
 
     public string? ZoneName { get; set; }

--- a/BistroQ.Presentation/App.xaml.cs
+++ b/BistroQ.Presentation/App.xaml.cs
@@ -8,6 +8,7 @@ using BistroQ.Presentation.Mappings;
 using BistroQ.Presentation.Models;
 using BistroQ.Presentation.Services;
 using BistroQ.Presentation.ViewModels;
+using BistroQ.Presentation.ViewModels.AdminAccount;
 using BistroQ.Presentation.ViewModels.AdminCategory;
 using BistroQ.Presentation.ViewModels.AdminProduct;
 using BistroQ.Presentation.ViewModels.AdminTable;
@@ -18,6 +19,7 @@ using BistroQ.Presentation.ViewModels.KitchenHistory;
 using BistroQ.Presentation.ViewModels.KitchenOrder;
 using BistroQ.Presentation.ViewModels.KitchenOrder.Strategies;
 using BistroQ.Presentation.Views;
+using BistroQ.Presentation.Views.AdminAccount;
 using BistroQ.Presentation.Views.AdminCategory;
 using BistroQ.Presentation.Views.AdminProduct;
 using BistroQ.Presentation.Views.AdminTable;
@@ -144,6 +146,12 @@ public partial class App : Application
             services.AddTransient<AdminProductAddPage>();
             services.AddTransient<AdminProductEditPageViewModel>();
             services.AddTransient<AdminProductEditPage>();
+            services.AddTransient<AdminAccountPage>();
+            services.AddTransient<AdminAccountViewModel>();
+            services.AddTransient<AdminAccountAddPage>();
+            services.AddTransient<AdminAccountAddPageViewModel>();
+            services.AddTransient<AdminAccountEditPage>();
+            services.AddTransient<AdminAccountEditPageViewModel>();
 
 
             services.AddScoped<IZoneDataService, ZoneDataService>();
@@ -153,6 +161,7 @@ public partial class App : Application
             services.AddScoped<ICategoryDataService, CategoryDataService>();
             services.AddScoped<IProductDataService, ProductDataService>();
             services.AddScoped<IDialogService, DialogService>();
+            services.AddScoped<IAccountDataService, AccountDataService>();
 
 
             // Client V&VM

--- a/BistroQ.Presentation/BistroQ.Presentation.csproj
+++ b/BistroQ.Presentation/BistroQ.Presentation.csproj
@@ -20,6 +20,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="Styles\Color.xaml" />
+    <None Remove="Views\AdminAccount\AdminAccountAddPage.xaml" />
+    <None Remove="Views\AdminAccount\AdminAccountEditPage.xaml" />
+    <None Remove="Views\AdminAccount\AdminAccountPage.xaml" />
     <None Remove="Views\AdminCategory\AdminCategoryAddPage.xaml" />
     <None Remove="Views\AdminCategory\AdminCategoryEditPage.xaml" />
     <None Remove="Views\AdminCategory\AdminCategoryPage.xaml" />
@@ -69,6 +72,15 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Page Update="Views\AdminAccount\AdminAccountPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Views\AdminAccount\AdminAccountAddPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Views\AdminAccount\AdminAccountEditPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Update="Views\AdminProduct\AdminProductPage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/BistroQ.Presentation/BistroQ.Presentation.sln
+++ b/BistroQ.Presentation/BistroQ.Presentation.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BistroQ.Presentation", "BistroQ.Presentation.csproj", "{96CD51CA-88F8-4E5B-B4F3-C2EFEA860DD1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{96CD51CA-88F8-4E5B-B4F3-C2EFEA860DD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96CD51CA-88F8-4E5B-B4F3-C2EFEA860DD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96CD51CA-88F8-4E5B-B4F3-C2EFEA860DD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96CD51CA-88F8-4E5B-B4F3-C2EFEA860DD1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C2B8E969-A012-43A7-A03A-5F79F2CDA703}
+	EndGlobalSection
+EndGlobal

--- a/BistroQ.Presentation/Mappings/MappingProfile.cs
+++ b/BistroQ.Presentation/Mappings/MappingProfile.cs
@@ -38,13 +38,9 @@ public class MappingProfile : Profile
 
         CreateMap<Account, AccountViewModel>()
             .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.Id))
-            .ForMember(dest => dest.TableDisplay,
-                opt => opt.MapFrom(src =>
-                    src.TableId.HasValue
-                        ? $"{src.Table.ZoneName} - Table {src.Table.Number}"
-                        : "No Table Assigned"))
             .ForMember(dest => dest.ZoneName, opt => opt.MapFrom(src => src.Table != null ? src.Table.ZoneName : null))
-            .ForMember(dest => dest.ZoneId, opt => opt.MapFrom(src => src.Table != null ? src.Table.ZoneId : null));
+            .ForMember(dest => dest.ZoneId, opt => opt.MapFrom(src => src.Table != null ? src.Table.ZoneId : null))
+            .ForMember(dest => dest.TableNumber, opt => opt.MapFrom(src => src.Table != null ? src.Table.Number : null));
 
         CreateMap<AccountViewModel, Account>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.UserId));

--- a/BistroQ.Presentation/Mappings/MappingProfile.cs
+++ b/BistroQ.Presentation/Mappings/MappingProfile.cs
@@ -83,13 +83,7 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.Products, opt => opt.MapFrom(src => src.Products));
 
         CreateMap<AccountResponse, Account>()
-            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
-            .ForMember(dest => dest.Table, opt => opt.MapFrom(src => new Table
-            {
-                TableId = src.TableId,
-                ZoneId = src.ZoneId,
-                ZoneName = src.ZoneName,
-                Number = src.TableNumber
-            }));
+            .ForMember(dest => dest.Table, opt => opt.MapFrom(src => src.Table))
+            .ForMember(dest => dest.TableId, opt => opt.MapFrom(src => src.Table.TableId));
     }
 }

--- a/BistroQ.Presentation/Mappings/MappingProfile.cs
+++ b/BistroQ.Presentation/Mappings/MappingProfile.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using BistroQ.Domain.Dtos.Account;
 using BistroQ.Domain.Dtos.Category;
 using BistroQ.Domain.Dtos.Order;
 using BistroQ.Domain.Dtos.Orders;
@@ -35,6 +36,19 @@ public class MappingProfile : Profile
         CreateMap<Category, CategoryViewModel>();
         CreateMap<Category, CategoryViewModel>().ReverseMap();
 
+        CreateMap<Account, AccountViewModel>()
+            .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.TableDisplay,
+                opt => opt.MapFrom(src =>
+                    src.TableId.HasValue
+                        ? $"{src.Table.ZoneName} - Table {src.Table.Number}"
+                        : "No Table Assigned"))
+            .ForMember(dest => dest.ZoneName, opt => opt.MapFrom(src => src.Table != null ? src.Table.ZoneName : null))
+            .ForMember(dest => dest.ZoneId, opt => opt.MapFrom(src => src.Table != null ? src.Table.ZoneId : null));
+
+        CreateMap<AccountViewModel, Account>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.UserId));
+
         /**
          * 
          * Dto to Domain
@@ -67,5 +81,15 @@ public class MappingProfile : Profile
 
         CreateMap<CategoryResponse, Category>()
             .ForMember(dest => dest.Products, opt => opt.MapFrom(src => src.Products));
+
+        CreateMap<AccountResponse, Account>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.Table, opt => opt.MapFrom(src => new Table
+            {
+                TableId = src.TableId,
+                ZoneId = src.ZoneId,
+                ZoneName = src.ZoneName,
+                Number = src.TableNumber
+            }));
     }
 }

--- a/BistroQ.Presentation/Models/AddAccountForm.cs
+++ b/BistroQ.Presentation/Models/AddAccountForm.cs
@@ -1,4 +1,6 @@
-﻿namespace BistroQ.Presentation.Models;
+﻿using BistroQ.Presentation.Validation;
+
+namespace BistroQ.Presentation.Models;
 
 public class AddAccountForm : ValidatorBase
 {
@@ -6,6 +8,7 @@ public class AddAccountForm : ValidatorBase
     private string _password;
     private string _role;
     private int? _tableId;
+    private int? _zoneId;
 
     public AddAccountForm()
     {
@@ -66,6 +69,19 @@ public class AddAccountForm : ValidatorBase
         }
     }
 
+    public int? ZoneId
+    {
+        get => _zoneId;
+        set
+        {
+            if (_zoneId != value)
+            {
+                _zoneId = value;
+                ValidateProperty(nameof(ZoneId), value);
+            }
+        }
+    }
+
     private void AddUsernameValidator()
     {
         AddValidator(nameof(Username), (value) =>
@@ -85,11 +101,7 @@ public class AddAccountForm : ValidatorBase
         {
             return value.Validate(
                 v => ValidationRules.StringRules.NotEmpty(v, "Password"),
-                v => ValidationRules.StringRules.MinLength(v, 6, "Password"),
-                v => ValidationRules.PasswordRules.RequireUppercase(v),
-                v => ValidationRules.PasswordRules.RequireLowercase(v),
-                v => ValidationRules.PasswordRules.RequireDigit(v),
-                v => ValidationRules.PasswordRules.RequireSpecialChar(v)
+                v => ValidationRules.StringRules.MinLength(v, 6, "Password")
             ).Where(r => !r.IsValid).ToList();
         });
     }
@@ -99,8 +111,7 @@ public class AddAccountForm : ValidatorBase
         AddValidator(nameof(Role), (value) =>
         {
             return value.Validate(
-                v => ValidationRules.StringRules.NotEmpty(v, "Role"),
-                v => ValidationRules.EnumRules.IsValidRole(v)
+                v => ValidationRules.StringRules.NotEmpty(v, "Role")
             ).Where(r => !r.IsValid).ToList();
         });
     }
@@ -110,59 +121,5 @@ public class AddAccountForm : ValidatorBase
         ValidateProperty(nameof(Username), Username);
         ValidateProperty(nameof(Password), Password);
         ValidateProperty(nameof(Role), Role);
-        // TableId is optional, so no validation needed
-    }
-}
-
-// Add these rules to your ValidationRules class if not already present
-public static class PasswordRules
-{
-    public static ValidationResult RequireUppercase(string value)
-    {
-        return new ValidationResult
-        {
-            IsValid = value?.Any(char.IsUpper) ?? false,
-            Message = "Password must contain at least one uppercase letter"
-        };
-    }
-
-    public static ValidationResult RequireLowercase(string value)
-    {
-        return new ValidationResult
-        {
-            IsValid = value?.Any(char.IsLower) ?? false,
-            Message = "Password must contain at least one lowercase letter"
-        };
-    }
-
-    public static ValidationResult RequireDigit(string value)
-    {
-        return new ValidationResult
-        {
-            IsValid = value?.Any(char.IsDigit) ?? false,
-            Message = "Password must contain at least one digit"
-        };
-    }
-
-    public static ValidationResult RequireSpecialChar(string value)
-    {
-        return new ValidationResult
-        {
-            IsValid = value?.Any(c => !char.IsLetterOrDigit(c)) ?? false,
-            Message = "Password must contain at least one special character"
-        };
-    }
-}
-
-public static class EnumRules
-{
-    public static ValidationResult IsValidRole(string value)
-    {
-        var validRoles = new[] { "Admin", "Staff", "Customer" };
-        return new ValidationResult
-        {
-            IsValid = validRoles.Contains(value),
-            Message = "Invalid role selected"
-        };
     }
 }

--- a/BistroQ.Presentation/Models/AddAccountForm.cs
+++ b/BistroQ.Presentation/Models/AddAccountForm.cs
@@ -4,82 +4,17 @@ namespace BistroQ.Presentation.Models;
 
 public class AddAccountForm : ValidatorBase
 {
-    private string _username;
-    private string _password;
-    private string _role;
-    private int? _tableId;
-    private int? _zoneId;
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+    public string? Role { get; set; }
+    public int? TableId { get; set; }
+    public int? ZoneId { get; set; }
 
     public AddAccountForm()
     {
         AddUsernameValidator();
         AddPasswordValidator();
         AddRoleValidator();
-    }
-
-    public string Username
-    {
-        get => _username;
-        set
-        {
-            if (_username != value)
-            {
-                _username = value;
-                ValidateProperty(nameof(Username), value);
-            }
-        }
-    }
-
-    public string Password
-    {
-        get => _password;
-        set
-        {
-            if (_password != value)
-            {
-                _password = value;
-                ValidateProperty(nameof(Password), value);
-            }
-        }
-    }
-
-    public string Role
-    {
-        get => _role;
-        set
-        {
-            if (_role != value)
-            {
-                _role = value;
-                ValidateProperty(nameof(Role), value);
-            }
-        }
-    }
-
-    public int? TableId
-    {
-        get => _tableId;
-        set
-        {
-            if (_tableId != value)
-            {
-                _tableId = value;
-                ValidateProperty(nameof(TableId), value);
-            }
-        }
-    }
-
-    public int? ZoneId
-    {
-        get => _zoneId;
-        set
-        {
-            if (_zoneId != value)
-            {
-                _zoneId = value;
-                ValidateProperty(nameof(ZoneId), value);
-            }
-        }
     }
 
     private void AddUsernameValidator()

--- a/BistroQ.Presentation/Models/AdminAccountForm.cs
+++ b/BistroQ.Presentation/Models/AdminAccountForm.cs
@@ -1,0 +1,168 @@
+﻿namespace BistroQ.Presentation.Models;
+
+public class AddAccountForm : ValidatorBase
+{
+    private string _username;
+    private string _password;
+    private string _role;
+    private int? _tableId;
+
+    public AddAccountForm()
+    {
+        AddUsernameValidator();
+        AddPasswordValidator();
+        AddRoleValidator();
+    }
+
+    public string Username
+    {
+        get => _username;
+        set
+        {
+            if (_username != value)
+            {
+                _username = value;
+                ValidateProperty(nameof(Username), value);
+            }
+        }
+    }
+
+    public string Password
+    {
+        get => _password;
+        set
+        {
+            if (_password != value)
+            {
+                _password = value;
+                ValidateProperty(nameof(Password), value);
+            }
+        }
+    }
+
+    public string Role
+    {
+        get => _role;
+        set
+        {
+            if (_role != value)
+            {
+                _role = value;
+                ValidateProperty(nameof(Role), value);
+            }
+        }
+    }
+
+    public int? TableId
+    {
+        get => _tableId;
+        set
+        {
+            if (_tableId != value)
+            {
+                _tableId = value;
+                ValidateProperty(nameof(TableId), value);
+            }
+        }
+    }
+
+    private void AddUsernameValidator()
+    {
+        AddValidator(nameof(Username), (value) =>
+        {
+            return value.Validate(
+                v => ValidationRules.StringRules.NotEmpty(v, "Username"),
+                v => ValidationRules.StringRules.MinLength(v, 3, "Username"),
+                v => ValidationRules.StringRules.MaxLength(v, 50, "Username"),
+                v => ValidationRules.StringRules.NoWhitespace(v, "Username")
+            ).Where(r => !r.IsValid).ToList();
+        });
+    }
+
+    private void AddPasswordValidator()
+    {
+        AddValidator(nameof(Password), (value) =>
+        {
+            return value.Validate(
+                v => ValidationRules.StringRules.NotEmpty(v, "Password"),
+                v => ValidationRules.StringRules.MinLength(v, 6, "Password"),
+                v => ValidationRules.PasswordRules.RequireUppercase(v),
+                v => ValidationRules.PasswordRules.RequireLowercase(v),
+                v => ValidationRules.PasswordRules.RequireDigit(v),
+                v => ValidationRules.PasswordRules.RequireSpecialChar(v)
+            ).Where(r => !r.IsValid).ToList();
+        });
+    }
+
+    private void AddRoleValidator()
+    {
+        AddValidator(nameof(Role), (value) =>
+        {
+            return value.Validate(
+                v => ValidationRules.StringRules.NotEmpty(v, "Role"),
+                v => ValidationRules.EnumRules.IsValidRole(v)
+            ).Where(r => !r.IsValid).ToList();
+        });
+    }
+
+    public override void ValidateAll()
+    {
+        ValidateProperty(nameof(Username), Username);
+        ValidateProperty(nameof(Password), Password);
+        ValidateProperty(nameof(Role), Role);
+        // TableId is optional, so no validation needed
+    }
+}
+
+// Add these rules to your ValidationRules class if not already present
+public static class PasswordRules
+{
+    public static ValidationResult RequireUppercase(string value)
+    {
+        return new ValidationResult
+        {
+            IsValid = value?.Any(char.IsUpper) ?? false,
+            Message = "Password must contain at least one uppercase letter"
+        };
+    }
+
+    public static ValidationResult RequireLowercase(string value)
+    {
+        return new ValidationResult
+        {
+            IsValid = value?.Any(char.IsLower) ?? false,
+            Message = "Password must contain at least one lowercase letter"
+        };
+    }
+
+    public static ValidationResult RequireDigit(string value)
+    {
+        return new ValidationResult
+        {
+            IsValid = value?.Any(char.IsDigit) ?? false,
+            Message = "Password must contain at least one digit"
+        };
+    }
+
+    public static ValidationResult RequireSpecialChar(string value)
+    {
+        return new ValidationResult
+        {
+            IsValid = value?.Any(c => !char.IsLetterOrDigit(c)) ?? false,
+            Message = "Password must contain at least one special character"
+        };
+    }
+}
+
+public static class EnumRules
+{
+    public static ValidationResult IsValidRole(string value)
+    {
+        var validRoles = new[] { "Admin", "Staff", "Customer" };
+        return new ValidationResult
+        {
+            IsValid = validRoles.Contains(value),
+            Message = "Invalid role selected"
+        };
+    }
+}

--- a/BistroQ.Presentation/Services/DialogService.cs
+++ b/BistroQ.Presentation/Services/DialogService.cs
@@ -8,6 +8,8 @@ public class DialogService : IDialogService
 {
     private readonly XamlRoot _xamlRoot;
     private static readonly SemaphoreSlim _semaphore = new(1);
+    private CancellationTokenSource? _currentDialogCts;
+
     public DialogService()
     {
         _xamlRoot = App.MainWindow.Content.XamlRoot;
@@ -25,15 +27,7 @@ public class DialogService : IDialogService
             SecondaryButtonStyle = Application.Current.Resources["AccentButtonStyle"] as Style
         };
 
-        await _semaphore.WaitAsync();
-        try
-        {
-            return await dialog.ShowAsync();
-        }
-        finally
-        {
-            _semaphore.Release();
-        }
+        return await ShowDialogCoreAsync(dialog);
     }
 
     public async Task ShowSuccessDialog(string message, string title = "Success")
@@ -45,44 +39,50 @@ public class DialogService : IDialogService
             Content = message,
             CloseButtonText = "OK"
         };
-        await _semaphore.WaitAsync();
-        try
-        {
-            await dialog.ShowAsync();
-        }
-        finally
-        {
-            _semaphore.Release();
-        }
+
+        await ShowDialogCoreAsync(dialog);
     }
 
     public async Task ShowErrorDialog(string message, string title = "Error")
     {
         var dialog = new ContentDialog
         {
-            XamlRoot = _xamlRoot,
             Title = title,
             Content = message,
             CloseButtonText = "OK"
         };
-        await _semaphore.WaitAsync();
-        try
-        {
-            await dialog.ShowAsync();
-        }
-        finally
-        {
-            _semaphore.Release();
-        }
+
+        await ShowDialogCoreAsync(dialog);
     }
 
     public async Task ShowDialogAsync(ContentDialog dialog)
     {
         dialog.XamlRoot = _xamlRoot;
+
+        await ShowDialogCoreAsync(dialog);
+    }
+
+    private async Task<ContentDialogResult> ShowDialogCoreAsync(ContentDialog dialog)
+    {
+        if (_currentDialogCts != null)
+        {
+            _currentDialogCts.Cancel();
+            _currentDialogCts.Dispose();
+        }
+
+        _currentDialogCts = new CancellationTokenSource();
+
+        dialog.XamlRoot = _xamlRoot;
+
         await _semaphore.WaitAsync();
         try
         {
-            await dialog.ShowAsync();
+            _currentDialogCts.Token.ThrowIfCancellationRequested();
+            return await dialog.ShowAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            return ContentDialogResult.None;
         }
         finally
         {

--- a/BistroQ.Presentation/Services/DialogService.cs
+++ b/BistroQ.Presentation/Services/DialogService.cs
@@ -8,8 +8,6 @@ public class DialogService : IDialogService
 {
     private readonly XamlRoot _xamlRoot;
     private static readonly SemaphoreSlim _semaphore = new(1);
-
-
     public DialogService()
     {
         _xamlRoot = App.MainWindow.Content.XamlRoot;

--- a/BistroQ.Presentation/Services/PageService.cs
+++ b/BistroQ.Presentation/Services/PageService.cs
@@ -1,5 +1,6 @@
 ﻿using BistroQ.Presentation.Contracts.Services;
 using BistroQ.Presentation.ViewModels;
+using BistroQ.Presentation.ViewModels.AdminAccount;
 using BistroQ.Presentation.ViewModels.AdminCategory;
 using BistroQ.Presentation.ViewModels.AdminProduct;
 using BistroQ.Presentation.ViewModels.AdminTable;
@@ -9,6 +10,7 @@ using BistroQ.Presentation.ViewModels.Client;
 using BistroQ.Presentation.ViewModels.KitchenHistory;
 using BistroQ.Presentation.ViewModels.KitchenOrder;
 using BistroQ.Presentation.Views;
+using BistroQ.Presentation.Views.AdminAccount;
 using BistroQ.Presentation.Views.AdminCategory;
 using BistroQ.Presentation.Views.AdminProduct;
 using BistroQ.Presentation.Views.AdminTable;
@@ -48,6 +50,10 @@ public class PageService : IPageService
         Configure<AdminProductViewModel, AdminProductPage>();
         Configure<AdminProductAddPageViewModel, AdminProductAddPage>();
         Configure<AdminProductEditPageViewModel, AdminProductEditPage>();
+
+        Configure<AdminAccountViewModel, AdminAccountPage>();
+        Configure<AdminAccountAddPageViewModel, AdminAccountAddPage>();
+        Configure<AdminAccountEditPageViewModel, AdminAccountEditPage>();
 
         Configure<KitchenOrderViewModel, KitchenOrderPage>();
         Configure<KitchenHistoryViewModel, KitchenHistoryPage>();

--- a/BistroQ.Presentation/Strings/en-us/Resources.resw
+++ b/BistroQ.Presentation/Strings/en-us/Resources.resw
@@ -245,7 +245,7 @@
     <value>Category name</value>
   </data>
 
-    <data name="Shell_AdminProduct.Content" xml:space="preserve">
+  <data name="Shell_AdminProduct.Content" xml:space="preserve">
     <value>Manage Products</value>
   </data>
   <data name="AdminProduct_DataGrid_Column_Id/Header" xml:space="preserve">
@@ -324,6 +324,100 @@
   </data>
   <data name="ProductEditPage_PreviewImage/AutomationProperties.Name" xml:space="preserve">
       <value>Product image preview</value>
+  </data>
+
+  <data name="AdminAccount_DataGrid_Column_UserId/Header" xml:space="preserve">
+    <value>User ID</value>
+  </data>
+  <data name="AdminAccount_DataGrid_Column_Username/Header" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="AdminAccount_DataGrid_Column_Role/Header" xml:space="preserve">
+    <value>Role</value>
+  </data>
+  <data name="AdminAccount_DataGrid_Column_TableId/Header" xml:space="preserve">
+    <value>Table</value>
+  </data>
+  <data name="AdminAccount_DataGrid_Column_ZoneName/Header" xml:space="preserve">
+    <value>Zone</value>
+  </data>
+
+  <data name="Shell_AdminAccount.Content" xml:space="preserve">
+    <value>Manage Accounts</value>
+  </data>
+  <data name="AdminAccount_DataGrid_AddNewButtonText/Text" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="AccountAddPage_UsernameTextBox/Header" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="AccountAddPage_UsernameTextBox/PlaceholderText" xml:space="preserve">
+    <value>Enter username</value>
+  </data>
+  <data name="AccountAddPage_PasswordBox/Header" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="AccountAddPage_PasswordBox/PlaceholderText" xml:space="preserve">
+    <value>Enter password</value>
+  </data>
+  <data name="AccountAddPage_RoleComboBox/Header" xml:space="preserve">
+    <value>Role</value>
+  </data>
+  <data name="AccountAddPage_RoleComboBox/PlaceholderText" xml:space="preserve">
+    <value>Select a role</value>
+  </data>
+  <data name="AccountAddPage_ZoneComboBox/Header" xml:space="preserve">
+    <value>Zone</value>
+  </data>
+  <data name="AccountAddPage_ZoneComboBox/PlaceholderText" xml:space="preserve">
+    <value>Select a zone</value>
+  </data>
+  <data name="AccountAddPage_TableComboBox/Header" xml:space="preserve">
+    <value>Table</value>
+  </data>
+  <data name="AccountAddPage_TableComboBox/PlaceholderText" xml:space="preserve">
+    <value>Select a table</value>
+  </data>
+  <data name="AdminAccountAddPage_AddButtonText/Text" xml:space="preserve">
+    <value>Add</value>
+  </data>
+
+  <data name="UserIdTextBox/Header" xml:space="preserve">
+    <value>User ID</value>
+  </data>
+  <data name="AccountEditPage_UsernameTextBox/Header" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="AccountEditPage_PasswordBox/Header" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="AccountEditPage_RoleComboBox/Header" xml:space="preserve">
+    <value>Role</value>
+  </data>
+  <data name="AccountEditPage_RoleComboBox/PlaceholderText" xml:space="preserve">
+    <value>Select a role</value>
+  </data>
+  <data name="AccountEditPage_ZoneComboBox/Header" xml:space="preserve">
+    <value>Zone</value>
+  </data>
+  <data name="AccountEditPage_ZoneComboBox/PlaceholderText" xml:space="preserve">
+    <value>Select a zone</value>
+  </data>
+  <data name="AccountEditPage_TableComboBox/Header" xml:space="preserve">
+    <value>Table</value>
+  </data>
+  <data name="AccountEditPage_TableComboBox/PlaceholderText" xml:space="preserve">
+    <value>Select a table</value>
+  </data>
+  <data name="AdminAccountEditPage_EditButton/Content" xml:space="preserve">
+    <value>Update</value>
+  </data>
+  <data name="AccountEditPage_EnablePasswordEdit/Content" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+
+  <data name="CancelButton/Content" xml:space="preserve">
+    <value>Cancel</value>
   </data>
 
   <data name="Shell_CashierTablePage.Content" xml:space="preserve">

--- a/BistroQ.Presentation/Validation/ValidationRules.cs
+++ b/BistroQ.Presentation/Validation/ValidationRules.cs
@@ -38,6 +38,22 @@ public static class ValidationRules
                 ? (true, string.Empty)
                 : (false, $"{fieldName} must contain only digits");
         }
+
+        public static (bool IsValid, string Message) MaxLength(object? value, int maxLength, string fieldName)
+        {
+            var strValue = value as string ?? string.Empty;
+            return strValue.Length > maxLength
+                ? (false, $"{fieldName} must be at most {maxLength} characters long")
+                : (true, string.Empty);
+        }
+
+        public static (bool IsValid, string Message) NoWhitespace(object? value, string fieldName)
+        {
+            var strValue = value as string ?? string.Empty;
+            return strValue.Contains(' ')
+                ? (false, $"{fieldName} must not contain whitespace")
+                : (true, string.Empty);
+        }
     }
 
     public static class DecimalRules

--- a/BistroQ.Presentation/ViewModels/AdminAccount/AdminAccountAddPageViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/AdminAccount/AdminAccountAddPageViewModel.cs
@@ -1,0 +1,149 @@
+﻿using AutoMapper;
+using BistroQ.Domain.Contracts.Services;
+using BistroQ.Presentation.Contracts.Services;
+using BistroQ.Presentation.ViewModels.Models;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+namespace BistroQ.Presentation.ViewModels.AdminAccount;
+
+public partial class AdminAccountAddPageViewModel : ObservableRecipient
+{
+    [ObservableProperty]
+    private bool _isProcessing = false;
+
+    [ObservableProperty]
+    private AddAccountForm _form = new();
+
+    [ObservableProperty]
+    private bool _isTableSelectionEnabled = false;
+
+    [ObservableProperty]
+    private int? _selectedZoneId;
+
+    public ObservableCollection<ZoneViewModel> Zones;
+    public ObservableCollection<TableViewModel> Tables;
+    public ObservableCollection<string> Roles;
+
+    public event EventHandler NavigateBack;
+
+    private readonly IAccountDataService _accountDataService;
+    private readonly IZoneDataService _zoneDataService;
+    private readonly ITableDataService _tableDataService;
+    private readonly IDialogService _dialogService;
+    private readonly IMapper _mapper;
+
+    public ICommand AddCommand { get; }
+
+    public AdminAccountAddPageViewModel(
+        IAccountDataService accountDataService,
+        IZoneDataService zoneDataService,
+        ITableDataService tableDataService,
+        IDialogService dialogService,
+        IMapper mapper)
+    {
+        _accountDataService = accountDataService;
+        _zoneDataService = zoneDataService;
+        _tableDataService = tableDataService;
+        _dialogService = dialogService;
+        _mapper = mapper;
+
+        Zones = new ObservableCollection<ZoneViewModel>();
+        Tables = new ObservableCollection<TableViewModel>();
+        Roles = new ObservableCollection<string> { "Admin", "Staff", "Customer" };
+
+        AddCommand = new AsyncRelayCommand(AddAccountAsync, CanAddAccount);
+
+        this.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(SelectedZoneId) && SelectedZoneId.HasValue)
+            {
+                _ = LoadTablesAsync(SelectedZoneId.Value);
+            }
+        };
+    }
+
+    private bool CanAddAccount()
+    {
+        return !IsProcessing;
+    }
+
+    public async Task AddAccountAsync()
+    {
+        try
+        {
+            IsProcessing = true;
+            Form.ValidateAll();
+
+            if (Form.HasErrors)
+            {
+                throw new InvalidDataException("Please fix all validation errors before proceeding.");
+            }
+
+            var request = new CreateAccountRequest
+            {
+                Username = Form.Username,
+                Password = Form.Password,
+                Role = Form.Role,
+                TableId = Form.TableId
+            };
+
+            await _accountDataService.CreateAccountAsync(request);
+
+            await _dialogService.ShowSuccessDialog("Account added successfully.", "Success");
+            NavigateBack?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorDialog(ex.Message, "Error");
+        }
+        finally
+        {
+            IsProcessing = false;
+        }
+    }
+
+    public async Task LoadZonesAsync()
+    {
+        try
+        {
+            var response = await _zoneDataService.GetGridDataAsync(new ZoneCollectionQueryParams
+            {
+                Size = 1000
+            });
+
+            Zones.Clear();
+            var zones = _mapper.Map<IEnumerable<ZoneViewModel>>(response.Data);
+            foreach (var zone in zones)
+            {
+                Zones.Add(zone);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorDialog(ex.Message, "Error");
+        }
+    }
+
+    public async Task LoadTablesAsync(int zoneId)
+    {
+        try
+        {
+            var tables = await _tableDataService.GetTablesByCashierAsync(zoneId, "All");
+            Tables.Clear();
+            var tableViewModels = _mapper.Map<IEnumerable<TableViewModel>>(tables);
+            foreach (var table in tableViewModels)
+            {
+                Tables.Add(table);
+            }
+            IsTableSelectionEnabled = true;
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorDialog(ex.Message, "Error");
+            IsTableSelectionEnabled = false;
+        }
+    }
+}

--- a/BistroQ.Presentation/ViewModels/AdminAccount/AdminAccountAddPageViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/AdminAccount/AdminAccountAddPageViewModel.cs
@@ -1,6 +1,9 @@
 ﻿using AutoMapper;
 using BistroQ.Domain.Contracts.Services;
+using BistroQ.Domain.Dtos.Account;
+using BistroQ.Domain.Dtos.Zones;
 using BistroQ.Presentation.Contracts.Services;
+using BistroQ.Presentation.Models;
 using BistroQ.Presentation.ViewModels.Models;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;

--- a/BistroQ.Presentation/ViewModels/AdminAccount/AdminAccountEditPageViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/AdminAccount/AdminAccountEditPageViewModel.cs
@@ -1,0 +1,176 @@
+﻿using AutoMapper;
+using BistroQ.Domain.Contracts.Services;
+using BistroQ.Domain.Dtos.Account;
+using BistroQ.Domain.Dtos.Zones;
+using BistroQ.Presentation.Contracts.Services;
+using BistroQ.Presentation.ViewModels.Models;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+namespace BistroQ.Presentation.ViewModels.AdminAccount;
+
+public partial class AdminAccountEditPageViewModel : ObservableRecipient
+{
+    public ObservableCollection<ZoneViewModel> Zones;
+    public ObservableCollection<TableViewModel> Tables;
+    public ObservableCollection<string> Roles;
+    public AccountViewModel Account { get; set; }
+
+    [ObservableProperty]
+    private UpdateAccountRequest _request;
+
+    [ObservableProperty]
+    private bool _isProcessing = false;
+
+    [ObservableProperty]
+    private bool _isPasswordEditEnabled = false;
+
+    [ObservableProperty]
+    private bool _isTableSelectionEnabled = false;
+
+    [ObservableProperty]
+    private int? _selectedZoneId;
+
+    private readonly IAccountDataService _accountDataService;
+    private readonly IZoneDataService _zoneDataService;
+    private readonly ITableDataService _tableDataService;
+    private readonly IDialogService _dialogService;
+    private readonly IMapper _mapper;
+
+    public ICommand EditCommand { get; }
+    public ICommand EnablePasswordEditCommand { get; }
+
+    public event EventHandler NavigateBack;
+
+    public AdminAccountEditPageViewModel(
+        IAccountDataService accountDataService,
+        IZoneDataService zoneDataService,
+        ITableDataService tableDataService,
+        IDialogService dialogService,
+        IMapper mapper)
+    {
+        _accountDataService = accountDataService;
+        _zoneDataService = zoneDataService;
+        _tableDataService = tableDataService;
+        _dialogService = dialogService;
+        _mapper = mapper;
+
+        Request = new UpdateAccountRequest();
+        Zones = new ObservableCollection<ZoneViewModel>();
+        Tables = new ObservableCollection<TableViewModel>();
+        Roles = new ObservableCollection<string> { "Admin", "Staff", "Customer" };
+
+        EditCommand = new AsyncRelayCommand(UpdateAccountAsync, CanEditAccount);
+        EnablePasswordEditCommand = new RelayCommand(EnablePasswordEdit);
+
+        this.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(SelectedZoneId) && SelectedZoneId.HasValue)
+            {
+                _ = LoadTablesAsync(SelectedZoneId.Value);
+            }
+        };
+    }
+
+    private void EnablePasswordEdit()
+    {
+        IsPasswordEditEnabled = true;
+    }
+
+    private bool CanEditAccount()
+    {
+        return !IsProcessing;
+    }
+
+    public async Task UpdateAccountAsync()
+    {
+        try
+        {
+            IsProcessing = true;
+
+            if (string.IsNullOrWhiteSpace(Request.Username))
+            {
+                throw new InvalidDataException("Username cannot be empty.");
+            }
+
+            if (IsPasswordEditEnabled && string.IsNullOrWhiteSpace(Request.Password))
+            {
+                throw new InvalidDataException("Password cannot be empty when editing.");
+            }
+
+            if (string.IsNullOrWhiteSpace(Request.Role))
+            {
+                throw new InvalidDataException("Role must be selected.");
+            }
+
+            await _accountDataService.UpdateAccountAsync(Account.UserId, Request);
+
+            await _dialogService.ShowSuccessDialog("Account updated successfully.", "Success");
+            NavigateBack?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorDialog(ex.Message, "Error");
+        }
+        finally
+        {
+            IsProcessing = false;
+        }
+    }
+
+    public async Task LoadZonesAsync()
+    {
+        try
+        {
+            var response = await _zoneDataService.GetGridDataAsync(new ZoneCollectionQueryParams
+            {
+                Size = 1000
+            });
+
+            Zones.Clear();
+            var zones = _mapper.Map<IEnumerable<ZoneViewModel>>(response.Data);
+            foreach (var zone in zones)
+            {
+                Zones.Add(zone);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorDialog(ex.Message, "Error");
+        }
+    }
+
+    public async Task LoadTablesAsync(int zoneId)
+    {
+        try
+        {
+            var tables = await _tableDataService.GetTablesByCashierAsync(zoneId, "All");
+            Tables.Clear();
+            var tableViewModels = _mapper.Map<IEnumerable<TableViewModel>>(tables);
+            foreach (var table in tableViewModels)
+            {
+                Tables.Add(table);
+            }
+            IsTableSelectionEnabled = true;
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorDialog(ex.Message, "Error");
+            IsTableSelectionEnabled = false;
+        }
+    }
+
+    public void OnNavigatedTo(AccountViewModel account)
+    {
+        if (account != null)
+        {
+            Account = account;
+            Request.Username = Account.Username;
+            Request.Role = Account.Role;
+            Request.TableId = Account.TableId;
+            SelectedZoneId = Account.TableId != null ? Tables.FirstOrDefault(t => t.TableId == Account.TableId)?.ZoneId : null;
+        }
+    }
+}

--- a/BistroQ.Presentation/ViewModels/AdminAccount/AdminAccountViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/AdminAccount/AdminAccountViewModel.cs
@@ -194,6 +194,7 @@ public partial class AdminAccountViewModel :
     public async void Receive(PageSizeChangedMessage message)
     {
         State.Query.Size = message.NewPageSize;
+        State.ReturnToFirstPage();
         await LoadDataAsync();
     }
 

--- a/BistroQ.Presentation/ViewModels/AdminAccount/AdminAccountViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/AdminAccount/AdminAccountViewModel.cs
@@ -1,0 +1,209 @@
+﻿using AutoMapper;
+using BistroQ.Presentation.Contracts.Services;
+using BistroQ.Presentation.Contracts.ViewModels;
+using BistroQ.Presentation.Messages;
+using BistroQ.Presentation.ViewModels.AdminAccount;
+using BistroQ.Presentation.ViewModels.Models;
+using BistroQ.Presentation.ViewModels.States;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using CommunityToolkit.WinUI.UI.Controls;
+using Microsoft.UI.Xaml.Controls;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Input;
+
+namespace BistroQ.Presentation.ViewModels;
+
+public partial class AdminAccountViewModel :
+    ObservableRecipient,
+    INavigationAware,
+    IDisposable,
+    IRecipient<PageSizeChangedMessage>,
+    IRecipient<CurrentPageChangedMessage>
+{
+    private readonly IDialogService _dialogService;
+    private readonly IMapper _mapper;
+    private readonly IAccountDataService _accountDataService;
+    private readonly INavigationService _navigationService;
+    private readonly IMessenger _messenger;
+
+    [ObservableProperty]
+    private AdminAccountState state = new();
+
+    public IRelayCommand AddCommand { get; }
+    public IRelayCommand EditCommand { get; }
+    public IAsyncRelayCommand DeleteCommand { get; }
+    public ICommand SortCommand { get; }
+    public ICommand SearchCommand { get; }
+
+    public AdminAccountViewModel(
+        INavigationService navigationService,
+        IAccountDataService accountDataService,
+        IDialogService dialogService,
+        IMapper mapper,
+        IMessenger messenger)
+    {
+        _navigationService = navigationService;
+        _accountDataService = accountDataService;
+        _mapper = mapper;
+        _messenger = messenger;
+        _dialogService = dialogService;
+
+        State.PropertyChanged += StatePropertyChanged;
+
+        AddCommand = new RelayCommand(NavigateToAddPage);
+        EditCommand = new RelayCommand(NavigateToEditPage, () => State.CanEdit);
+        DeleteCommand = new AsyncRelayCommand(DeleteSelectedAccountAsync, () => State.CanDelete);
+        SortCommand = new RelayCommand<(string column, string direction)>(ExecuteSortCommand);
+        SearchCommand = new RelayCommand(ExecuteSearchCommand);
+
+        _messenger.RegisterAll(this);
+    }
+
+    private void StatePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(State.SelectedAccount))
+        {
+            EditCommand.NotifyCanExecuteChanged();
+            DeleteCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    public async void OnNavigatedTo(object parameter)
+    {
+        await LoadDataAsync();
+    }
+
+    public void OnNavigatedFrom()
+    {
+        State.SelectedAccount = null;
+    }
+
+    private async Task LoadDataAsync()
+    {
+        try
+        {
+            State.IsLoading = true;
+
+            var result = await _accountDataService.GetGridDataAsync(State.Query);
+
+            var accounts = _mapper.Map<IEnumerable<AccountViewModel>>(result.Data);
+            State.Source = new ObservableCollection<AccountViewModel>(accounts);
+            _messenger.Send(new PaginationChangedMessage(
+                result.TotalItems,
+                result.CurrentPage,
+                result.TotalPages
+             ));
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorDialog(ex.Message, "Error");
+        }
+        finally
+        {
+            State.IsLoading = false;
+        }
+    }
+
+    private void NavigateToAddPage() =>
+        _navigationService.NavigateTo(typeof(AdminAccountAddPageViewModel).FullName);
+
+    private void NavigateToEditPage()
+    {
+        if (State.SelectedAccount?.UserId != null)
+        {
+            _navigationService.NavigateTo(typeof(AdminAccountEditPageViewModel).FullName, State.SelectedAccount);
+        }
+    }
+
+    private async Task DeleteSelectedAccountAsync()
+    {
+        if (State.SelectedAccount?.UserId == null) return;
+
+        try
+        {
+            var result = await _dialogService.ShowConfirmDeleteDialog();
+            if (result != ContentDialogResult.Primary) return;
+
+            var success = await _accountDataService.DeleteAccountAsync(State.SelectedAccount.UserId);
+            if (success)
+            {
+                await _dialogService.ShowSuccessDialog("Account deleted successfully.", "Success");
+                State.Source.Remove(State.SelectedAccount);
+                State.SelectedAccount = null;
+                await LoadDataAsync();
+            }
+            else
+            {
+                await _dialogService.ShowErrorDialog("Failed to delete account.", "Error");
+            }
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorDialog(ex.Message, "Error");
+        }
+    }
+
+    private void ExecuteSortCommand((string column, string direction) sortParams)
+    {
+        var (column, direction) = sortParams;
+        State.Query.OrderBy = column;
+        State.Query.OrderDirection = direction;
+        State.ReturnToFirstPage();
+        _ = LoadDataAsync();
+    }
+
+    public void AdminAccountDataGrid_Sorting(object sender, DataGridColumnEventArgs e)
+    {
+        var dataGrid = sender as DataGrid;
+        var column = e.Column;
+        var sortDirection = column.SortDirection == null || column.SortDirection == DataGridSortDirection.Descending
+            ? "asc"
+            : "des";
+
+        foreach (var col in dataGrid.Columns)
+        {
+            if (col != column)
+            {
+                col.SortDirection = null;
+            }
+        }
+
+        column.SortDirection = sortDirection == "asc"
+            ? DataGridSortDirection.Ascending
+            : DataGridSortDirection.Descending;
+
+        var sortParams = (column.Tag.ToString(), sortDirection);
+        SortCommand.Execute(sortParams);
+    }
+
+    private void ExecuteSearchCommand()
+    {
+        State.ReturnToFirstPage();
+        _ = LoadDataAsync();
+    }
+
+    public async void Receive(CurrentPageChangedMessage message)
+    {
+        State.Query.Page = message.NewCurrentPage;
+        await LoadDataAsync();
+    }
+
+    public async void Receive(PageSizeChangedMessage message)
+    {
+        State.Query.Size = message.NewPageSize;
+        await LoadDataAsync();
+    }
+
+    public void Dispose()
+    {
+        if (State != null)
+        {
+            State.PropertyChanged -= StatePropertyChanged;
+        }
+
+        _messenger.UnregisterAll(this);
+    }
+}

--- a/BistroQ.Presentation/ViewModels/AdminCategory/AdminCategoryViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/AdminCategory/AdminCategoryViewModel.cs
@@ -61,6 +61,7 @@ public partial class AdminCategoryViewModel :
         _messenger.Register<PageSizeChangedMessage>(this, async (r, m) =>
         {
             State.Query.Size = m.NewPageSize;
+            State.ReturnToFirstPage();
             await LoadDataAsync();
         });
 

--- a/BistroQ.Presentation/ViewModels/AdminProduct/AdminProductViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/AdminProduct/AdminProductViewModel.cs
@@ -66,6 +66,7 @@ public partial class AdminProductViewModel :
         _messenger.Register<PageSizeChangedMessage>(this, async (r, m) =>
         {
             State.Query.Size = m.NewPageSize;
+            State.ReturnToFirstPage();
             await LoadDataAsync();
         });
 

--- a/BistroQ.Presentation/ViewModels/AdminTable/AdminTableViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/AdminTable/AdminTableViewModel.cs
@@ -193,6 +193,7 @@ public partial class AdminTableViewModel :
     public async void Receive(PageSizeChangedMessage message)
     {
         State.Query.Size = message.NewPageSize;
+        State.ReturnToFirstPage();
         await LoadDataAsync();
     }
 

--- a/BistroQ.Presentation/ViewModels/AdminZone/AdminZoneViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/AdminZone/AdminZoneViewModel.cs
@@ -61,6 +61,7 @@ public partial class AdminZoneViewModel :
         _messenger.Register<PageSizeChangedMessage>(this, async (r, m) =>
         {
             State.Query.Size = m.NewPageSize;
+            State.ReturnToFirstPage();
             await LoadDataAsync();
         });
 

--- a/BistroQ.Presentation/ViewModels/Models/AccountViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/Models/AccountViewModel.cs
@@ -1,0 +1,34 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace BistroQ.Presentation.ViewModels.Models;
+
+public partial class AccountViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string? _userId;
+
+    [ObservableProperty]
+    private string? _username;
+
+    [ObservableProperty]
+    private string? _role;
+
+    [ObservableProperty]
+    private int? _tableId;
+
+    [ObservableProperty]
+    private string? _tableName;
+
+    [ObservableProperty]
+    private string? _zoneName;
+
+    [ObservableProperty]
+    private int? _zoneId;
+
+    public string TableDisplay => TableId.HasValue
+        ? $"{ZoneName} - Table {TableId}"
+        : "No Table Assigned";
+
+    public bool IsSystemAdmin => Role?.ToLower() == "admin" &&
+                               Username?.ToLower() == "admin";
+}

--- a/BistroQ.Presentation/ViewModels/Models/AccountViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/Models/AccountViewModel.cs
@@ -17,9 +17,6 @@ public partial class AccountViewModel : ObservableObject
     private int? _tableId;
 
     [ObservableProperty]
-    private string? _tableName;
-
-    [ObservableProperty]
     private string? _zoneName;
 
     [ObservableProperty]

--- a/BistroQ.Presentation/ViewModels/Models/AccountViewModel.cs
+++ b/BistroQ.Presentation/ViewModels/Models/AccountViewModel.cs
@@ -17,13 +17,16 @@ public partial class AccountViewModel : ObservableObject
     private int? _tableId;
 
     [ObservableProperty]
+    private int? _tableNumber;
+
+    [ObservableProperty]
     private string? _zoneName;
 
     [ObservableProperty]
     private int? _zoneId;
 
     public string TableDisplay => TableId.HasValue
-        ? $"{ZoneName} - Table {TableId}"
+        ? $"{ZoneName} - Table {TableNumber}"
         : "No Table Assigned";
 
     public bool IsSystemAdmin => Role?.ToLower() == "admin" &&

--- a/BistroQ.Presentation/ViewModels/States/AdminAccountState.cs
+++ b/BistroQ.Presentation/ViewModels/States/AdminAccountState.cs
@@ -1,0 +1,55 @@
+﻿using BistroQ.Domain.Dtos.Account;
+using BistroQ.Presentation.ViewModels.Models;
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.ObjectModel;
+
+namespace BistroQ.Presentation.ViewModels.States;
+
+public partial class AdminAccountState : ObservableObject
+{
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SearchText))]
+    private AccountCollectionQueryParams _query = new();
+
+    [ObservableProperty]
+    private AccountViewModel? _selectedAccount;
+
+    [ObservableProperty]
+    private ObservableCollection<AccountViewModel> _source = new();
+
+    [ObservableProperty]
+    private bool _isLoading;
+
+    public string SearchText
+    {
+        get => Query.Username ?? string.Empty;
+        set
+        {
+            if (Query.Username != value)
+            {
+                Query.Username = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public bool CanEdit => SelectedAccount != null;
+    public bool CanDelete => SelectedAccount != null && !IsDefaultAdmin;
+
+    // Prevent deletion of default admin account
+    private bool IsDefaultAdmin => SelectedAccount?.Role == "Admin" &&
+                                 SelectedAccount?.Username?.ToLower() == "admin";
+
+    public void Reset()
+    {
+        SelectedAccount = null;
+        Source.Clear();
+        IsLoading = false;
+        Query = new AccountCollectionQueryParams();
+    }
+
+    public void ReturnToFirstPage()
+    {
+        Query.Page = 1;
+    }
+}

--- a/BistroQ.Presentation/Views/AdminAccount/AdminAccountAddPage.xaml
+++ b/BistroQ.Presentation/Views/AdminAccount/AdminAccountAddPage.xaml
@@ -14,6 +14,7 @@
     <Page.Resources>
         <converter:ReverseBooleanConverter x:Key="ReverseBool"/>
         <converter:BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
+        <converter:FirstValidationErrorConverter x:Key="FirstError"/>
     </Page.Resources>
 
     <Grid Background="Transparent">
@@ -22,57 +23,92 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Vertical" Background="Transparent" HorizontalAlignment="Left">
-            <TextBox x:Name="AccountAddPage_UsernameTextBox"
-                     x:Uid="AccountAddPage_UsernameTextBox"
-                     GettingFocus="AccountAddPage_UsernameTextBox_GettingFocus"
-                     Text="{x:Bind ViewModel.Form.Username, Mode=TwoWay}"
-                     PlaceholderText="Enter username"
-                     Width="300"
-                     Margin="0,0,0,16" />
+        <StackPanel Orientation="Vertical" Background="Transparent" HorizontalAlignment="Left" Margin="24">
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+                <TextBox x:Name="AccountAddPage_UsernameTextBox"
+                        x:Uid="AccountAddPage_UsernameTextBox"
+                        GettingFocus="AccountAddPage_UsernameTextBox_GettingFocus"
+                        Text="{x:Bind ViewModel.Form.Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        Width="300" />
+                <TextBlock Text="{x:Bind ViewModel.Form.Errors, 
+                                Mode=OneWay, 
+                                Converter={StaticResource FirstError},
+                                ConverterParameter=Username}"
+                         Margin="0,8,0,16"
+                         Foreground="Red"/>
+            </StackPanel>
 
-            <PasswordBox x:Name="AccountAddPage_PasswordBox"
-                        x:Uid="AccountAddPage_PasswordBox"
-                        GettingFocus="AccountAddPage_PasswordBox_GettingFocus"
-                        Password="{x:Bind ViewModel.Form.Password, Mode=TwoWay}"
-                        PlaceholderText="Enter password"
-                        Width="300"
-                        Margin="0,0,0,16" />
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+                <PasswordBox x:Name="AccountAddPage_PasswordBox"
+                           x:Uid="AccountAddPage_PasswordBox"
+                           GettingFocus="AccountAddPage_PasswordBox_GettingFocus"
+                           Password="{x:Bind ViewModel.Form.Password, Mode=TwoWay}"
+                           Width="300" />
+                <TextBlock Text="{x:Bind ViewModel.Form.Errors, 
+                                Mode=OneWay, 
+                                Converter={StaticResource FirstError},
+                                ConverterParameter=Password}"
+                         Margin="0,8,0,16"
+                         Foreground="Red"/>
+            </StackPanel>
 
-            <ComboBox x:Name="AccountAddPage_RoleComboBox"
-                      x:Uid="AccountAddPage_RoleComboBox"
-                      GettingFocus="AccountAddPage_RoleComboBox_GettingFocus"
-                      ItemsSource="{x:Bind ViewModel.Roles}"
-                      SelectedValue="{x:Bind ViewModel.Form.Role, Mode=TwoWay}"
-                      PlaceholderText="Select role"
-                      Width="300"
-                      Margin="0,0,0,16" />
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+                <ComboBox x:Name="AccountAddPage_RoleComboBox"
+                         x:Uid="AccountAddPage_RoleComboBox"
+                         GettingFocus="AccountAddPage_RoleComboBox_GettingFocus"
+                         ItemsSource="{x:Bind ViewModel.Roles}"
+                         SelectedValue="{x:Bind ViewModel.Form.Role, Mode=TwoWay}"
+                         Width="300" />
+                <TextBlock Text="{x:Bind ViewModel.Form.Errors, 
+                                Mode=OneWay, 
+                                Converter={StaticResource FirstError},
+                                ConverterParameter=Role}"
+                         Margin="0,8,0,16"
+                         Foreground="Red"/>
+            </StackPanel>
 
-            <ComboBox x:Name="AccountAddPage_ZoneComboBox"
-                      x:Uid="AccountAddPage_ZoneComboBox"
-                      GettingFocus="AccountAddPage_ZoneComboBox_GettingFocus"
-                      ItemsSource="{x:Bind ViewModel.Zones, Mode=OneWay}"
-                      DisplayMemberPath="Name"
-                      SelectedValuePath="ZoneId"
-                      SelectedValue="{x:Bind ViewModel.SelectedZoneId, Mode=TwoWay}"
-                      PlaceholderText="Select zone"
-                      Width="300"
-                      Margin="0,0,0,16" />
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+                <ComboBox x:Name="AccountAddPage_ZoneComboBox"
+                         x:Uid="AccountAddPage_ZoneComboBox"
+                         GettingFocus="AccountAddPage_ZoneComboBox_GettingFocus"
+                         ItemsSource="{x:Bind ViewModel.Zones, Mode=OneWay}"
+                         DisplayMemberPath="Name"
+                         SelectedValuePath="ZoneId"
+                         SelectedValue="{x:Bind ViewModel.SelectedZoneId, Mode=TwoWay}"
+                         Width="300" />
+                <TextBlock Text="{x:Bind ViewModel.Form.Errors, 
+                                Mode=OneWay, 
+                                Converter={StaticResource FirstError},
+                                ConverterParameter=ZoneId}"
+                         Margin="0,8,0,16"
+                         Foreground="Red"/>
+            </StackPanel>
 
-            <ComboBox x:Name="AccountAddPage_TableComboBox"
-                      x:Uid="AccountAddPage_TableComboBox"
-                      GettingFocus="AccountAddPage_TableComboBox_GettingFocus"
-                      ItemsSource="{x:Bind ViewModel.Tables, Mode=OneWay}"
-                      DisplayMemberPath="Number"
-                      SelectedValuePath="TableId"
-                      SelectedValue="{x:Bind ViewModel.Form.TableId, Mode=TwoWay}"
-                      IsEnabled="{x:Bind ViewModel.IsTableSelectionEnabled, Mode=OneWay}"
-                      PlaceholderText="Select table"
-                      Width="300" />
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+                <ComboBox x:Name="AccountAddPage_TableComboBox"
+                         x:Uid="AccountAddPage_TableComboBox"
+                         GettingFocus="AccountAddPage_TableComboBox_GettingFocus"
+                         ItemsSource="{x:Bind ViewModel.Tables, Mode=OneWay}"
+                         DisplayMemberPath="Number"
+                         SelectedValuePath="TableId"
+                         SelectedValue="{x:Bind ViewModel.Form.TableId, Mode=TwoWay}"
+                         IsEnabled="{x:Bind ViewModel.IsTableSelectionEnabled, Mode=OneWay}"
+                         Width="300" />
+                <TextBlock Text="{x:Bind ViewModel.Form.Errors, 
+                                Mode=OneWay, 
+                                Converter={StaticResource FirstError},
+                                ConverterParameter=TableId}"
+                         Margin="0,8,0,16"
+                         Foreground="Red"/>
+            </StackPanel>
         </StackPanel>
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource AccentButtonStyle}" Width="80"
+        <StackPanel Grid.Row="1" 
+                    Orientation="Horizontal" 
+                    HorizontalAlignment="Right"
+                    Margin="24">
+            <Button Style="{StaticResource AccentButtonStyle}" 
+                    Width="80"
                     Command="{x:Bind ViewModel.AddCommand}"
                     IsEnabled="{x:Bind ViewModel.IsProcessing, Mode=OneWay, Converter={StaticResource ReverseBool}}"
                     Margin="0,0,16,0">
@@ -85,12 +121,12 @@
 
                     <TextBlock 
                         x:Uid="AdminAccountAddPage_AddButtonText"
-                        Text="Add" 
                         Visibility="{x:Bind ViewModel.IsProcessing, Mode=OneWay, 
                                     Converter={StaticResource BoolToVisibility}, 
                                     ConverterParameter=invert}"/>
                 </Grid>
             </Button>
+
             <Button x:Name="AdminAccountAddPage_CancelButton"
                     x:Uid="CancelButton" 
                     Width="80" 

--- a/BistroQ.Presentation/Views/AdminAccount/AdminAccountAddPage.xaml
+++ b/BistroQ.Presentation/Views/AdminAccount/AdminAccountAddPage.xaml
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="BistroQ.Presentation.Views.AdminAccount.AdminAccountAddPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:BistroQ.Presentation.Views.AdminAccount"
+    xmlns:control="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converter="using:BistroQ.Presentation.Converters"
+    mc:Ignorable="d"
+    Background="Transparent">
+
+    <Page.Resources>
+        <converter:ReverseBooleanConverter x:Key="ReverseBool"/>
+        <converter:BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
+    </Page.Resources>
+
+    <Grid Background="Transparent">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Vertical" Background="Transparent" HorizontalAlignment="Left">
+            <TextBox x:Name="AccountAddPage_UsernameTextBox"
+                     x:Uid="AccountAddPage_UsernameTextBox"
+                     GettingFocus="AccountAddPage_UsernameTextBox_GettingFocus"
+                     Text="{x:Bind ViewModel.Form.Username, Mode=TwoWay}"
+                     PlaceholderText="Enter username"
+                     Width="300"
+                     Margin="0,0,0,16" />
+
+            <PasswordBox x:Name="AccountAddPage_PasswordBox"
+                        x:Uid="AccountAddPage_PasswordBox"
+                        GettingFocus="AccountAddPage_PasswordBox_GettingFocus"
+                        Password="{x:Bind ViewModel.Form.Password, Mode=TwoWay}"
+                        PlaceholderText="Enter password"
+                        Width="300"
+                        Margin="0,0,0,16" />
+
+            <ComboBox x:Name="AccountAddPage_RoleComboBox"
+                      x:Uid="AccountAddPage_RoleComboBox"
+                      GettingFocus="AccountAddPage_RoleComboBox_GettingFocus"
+                      ItemsSource="{x:Bind ViewModel.Roles}"
+                      SelectedValue="{x:Bind ViewModel.Form.Role, Mode=TwoWay}"
+                      PlaceholderText="Select role"
+                      Width="300"
+                      Margin="0,0,0,16" />
+
+            <ComboBox x:Name="AccountAddPage_ZoneComboBox"
+                      x:Uid="AccountAddPage_ZoneComboBox"
+                      GettingFocus="AccountAddPage_ZoneComboBox_GettingFocus"
+                      ItemsSource="{x:Bind ViewModel.Zones, Mode=OneWay}"
+                      DisplayMemberPath="Name"
+                      SelectedValuePath="ZoneId"
+                      SelectedValue="{x:Bind ViewModel.SelectedZoneId, Mode=TwoWay}"
+                      PlaceholderText="Select zone"
+                      Width="300"
+                      Margin="0,0,0,16" />
+
+            <ComboBox x:Name="AccountAddPage_TableComboBox"
+                      x:Uid="AccountAddPage_TableComboBox"
+                      GettingFocus="AccountAddPage_TableComboBox_GettingFocus"
+                      ItemsSource="{x:Bind ViewModel.Tables, Mode=OneWay}"
+                      DisplayMemberPath="Number"
+                      SelectedValuePath="TableId"
+                      SelectedValue="{x:Bind ViewModel.Form.TableId, Mode=TwoWay}"
+                      IsEnabled="{x:Bind ViewModel.IsTableSelectionEnabled, Mode=OneWay}"
+                      PlaceholderText="Select table"
+                      Width="300" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Style="{StaticResource AccentButtonStyle}" Width="80"
+                    Command="{x:Bind ViewModel.AddCommand}"
+                    IsEnabled="{x:Bind ViewModel.IsProcessing, Mode=OneWay, Converter={StaticResource ReverseBool}}"
+                    Margin="0,0,16,0">
+                <Grid>
+                    <control:ProgressRing
+                        IsActive="{x:Bind ViewModel.IsProcessing, Mode=OneWay}"
+                        Foreground="White"
+                        Width="20"
+                        Height="20"/>
+
+                    <TextBlock 
+                        x:Uid="AdminAccountAddPage_AddButtonText"
+                        Text="Add" 
+                        Visibility="{x:Bind ViewModel.IsProcessing, Mode=OneWay, 
+                                    Converter={StaticResource BoolToVisibility}, 
+                                    ConverterParameter=invert}"/>
+                </Grid>
+            </Button>
+            <Button x:Name="AdminAccountAddPage_CancelButton"
+                    x:Uid="CancelButton" 
+                    Width="80" 
+                    Click="AdminAccountAddPage_CancelButton_Click"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/BistroQ.Presentation/Views/AdminAccount/AdminAccountAddPage.xaml.cs
+++ b/BistroQ.Presentation/Views/AdminAccount/AdminAccountAddPage.xaml.cs
@@ -1,0 +1,64 @@
+﻿using BistroQ.Presentation.ViewModels.AdminAccount;
+using Microsoft.UI.Xaml.Controls;
+
+namespace BistroQ.Presentation.Views.AdminAccount;
+
+public sealed partial class AdminAccountAddPage : Page
+{
+    public AdminAccountAddPageViewModel ViewModel { get; set; }
+
+    public AdminAccountAddPage()
+    {
+        this.InitializeComponent();
+        ViewModel = App.GetService<AdminAccountAddPageViewModel>();
+        this.DataContext = ViewModel;
+
+        this.Loaded += AdminAccountAddPage_Loaded;
+        ViewModel.NavigateBack += OnNavigateBack;
+
+        Unloaded += (s, e) =>
+        {
+            ViewModel.NavigateBack -= OnNavigateBack;
+        };
+    }
+
+    private async void AdminAccountAddPage_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        await ViewModel.LoadZonesAsync();
+    }
+
+    private void AdminAccountAddPage_CancelButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        Frame.GoBack();
+    }
+
+    private void OnNavigateBack(object sender, EventArgs e)
+    {
+        Frame.GoBack();
+    }
+
+    private void AccountAddPage_UsernameTextBox_GettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        ViewModel.Form.ResetError(nameof(ViewModel.Form.Username));
+    }
+
+    private void AccountAddPage_PasswordBox_GettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        ViewModel.Form.ResetError(nameof(ViewModel.Form.Password));
+    }
+
+    private void AccountAddPage_RoleComboBox_GettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        ViewModel.Form.ResetError(nameof(ViewModel.Form.Role));
+    }
+
+    private void AccountAddPage_ZoneComboBox_GettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        ViewModel.Form.ResetError(nameof(ViewModel.Form.ZoneId));
+    }
+
+    private void AccountAddPage_TableComboBox_GettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        ViewModel.Form.ResetError(nameof(ViewModel.Form.TableId));
+    }
+}

--- a/BistroQ.Presentation/Views/AdminAccount/AdminAccountEditPage.xaml
+++ b/BistroQ.Presentation/Views/AdminAccount/AdminAccountEditPage.xaml
@@ -1,0 +1,110 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="BistroQ.Presentation.Views.AdminAccount.AdminAccountEditPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:BistroQ.Presentation.Views.AdminAccount"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converter="using:BistroQ.Presentation.Converters"
+    mc:Ignorable="d"
+    Background="Transparent">
+
+    <Page.Resources>
+        <converter:ReverseBooleanConverter x:Key="ReverseBool"/>
+        <converter:BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
+    </Page.Resources>
+
+    <Grid Background="Transparent">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Vertical" Background="Transparent" HorizontalAlignment="Left">
+            <TextBox x:Name="UserIdTextBox"
+                     x:Uid="UserIdTextBox"
+                     Text="{x:Bind ViewModel.Account.UserId, Mode=OneTime}"
+                     IsReadOnly="True"
+                     IsEnabled="False"
+                     Width="300"
+                     Margin="0,0,0,16" />
+
+            <TextBox x:Name="AccountEditPage_UsernameTextBox"
+                     x:Uid="AccountEditPage_UsernameTextBox"
+                     Text="{x:Bind ViewModel.Request.Username, Mode=TwoWay}"
+                     Width="300"
+                     Margin="0,0,0,16" />
+
+            <Grid Width="300" Margin="0,0,0,16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <PasswordBox x:Name="AccountEditPage_PasswordBox"
+                            x:Uid="AccountEditPage_PasswordBox"
+                            Password="{x:Bind ViewModel.Request.Password, Mode=TwoWay}"
+                            IsEnabled="{x:Bind ViewModel.IsPasswordEditEnabled, Mode=OneWay}"
+                            Width="240"/>
+
+                <Button Grid.Column="1"
+                        x:Name="EnablePasswordEditButton"
+                        Content="Edit"
+                        Command="{x:Bind ViewModel.EnablePasswordEditCommand}"
+                        Margin="8,0,0,0"/>
+            </Grid>
+
+            <ComboBox x:Name="AccountEditPage_RoleComboBox"
+                      x:Uid="AccountEditPage_RoleComboBox"
+                      ItemsSource="{x:Bind ViewModel.Roles}"
+                      SelectedValue="{x:Bind ViewModel.Request.Role, Mode=TwoWay}"
+                      Width="300"
+                      Margin="0,0,0,16" />
+
+            <ComboBox x:Name="AccountEditPage_ZoneComboBox"
+                      x:Uid="AccountEditPage_ZoneComboBox"
+                      ItemsSource="{x:Bind ViewModel.Zones, Mode=OneWay}"
+                      DisplayMemberPath="Name"
+                      SelectedValuePath="ZoneId"
+                      SelectedValue="{x:Bind ViewModel.SelectedZoneId, Mode=TwoWay}"
+                      Width="300"
+                      Margin="0,0,0,16" />
+
+            <ComboBox x:Name="AccountEditPage_TableComboBox"
+                      x:Uid="AccountEditPage_TableComboBox"
+                      ItemsSource="{x:Bind ViewModel.Tables, Mode=OneWay}"
+                      DisplayMemberPath="Number"
+                      SelectedValuePath="TableId"
+                      SelectedValue="{x:Bind ViewModel.Request.TableId, Mode=TwoWay}"
+                      IsEnabled="{x:Bind ViewModel.IsTableSelectionEnabled, Mode=OneWay}"
+                      Width="300" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="AdminAccountEditPage_EditButton"
+                    x:Uid="AdminAccountEditPage_EditButton" 
+                    Style="{StaticResource AccentButtonStyle}" 
+                    Width="80"
+                    Command="{x:Bind ViewModel.EditCommand}"
+                    IsEnabled="{x:Bind ViewModel.IsProcessing, Mode=OneWay, Converter={StaticResource ReverseBool}}"
+                    Margin="0,0,16,0">
+                <Grid>
+                    <ProgressRing IsActive="{x:Bind ViewModel.IsProcessing, Mode=OneWay}"
+                                 Foreground="White"
+                                 Width="20"
+                                 Height="20"/>
+                    <TextBlock Text="Save"
+                             Visibility="{x:Bind ViewModel.IsProcessing, Mode=OneWay, 
+                                         Converter={StaticResource BoolToVisibility}, 
+                                         ConverterParameter=invert}"/>
+                </Grid>
+            </Button>
+
+            <Button x:Name="AdminAccountEditPage_CancelButton"
+                    x:Uid="CancelButton" 
+                    Width="80" 
+                    Click="AdminAccountEditPage_CancelButton_Click"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/BistroQ.Presentation/Views/AdminAccount/AdminAccountEditPage.xaml
+++ b/BistroQ.Presentation/Views/AdminAccount/AdminAccountEditPage.xaml
@@ -7,12 +7,15 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:converter="using:BistroQ.Presentation.Converters"
+    xmlns:control="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     mc:Ignorable="d"
     Background="Transparent">
 
     <Page.Resources>
         <converter:ReverseBooleanConverter x:Key="ReverseBool"/>
         <converter:BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
+        <converter:StringToVisibilityConverter x:Key="StringToVisibility"/>
+        <converter:FirstValidationErrorConverter x:Key="FirstError"/>
     </Page.Resources>
 
     <Grid Background="Transparent">
@@ -21,67 +24,119 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Vertical" Background="Transparent" HorizontalAlignment="Left">
+        <StackPanel Orientation="Vertical" Background="Transparent" HorizontalAlignment="Left" Margin="24">
+            <!-- User ID (Read-only) -->
             <TextBox x:Name="UserIdTextBox"
-                     x:Uid="UserIdTextBox"
-                     Text="{x:Bind ViewModel.Account.UserId, Mode=OneTime}"
-                     IsReadOnly="True"
-                     IsEnabled="False"
-                     Width="300"
-                     Margin="0,0,0,16" />
+                    x:Uid="UserIdTextBox"
+                    Text="{x:Bind ViewModel.Account.UserId, Mode=OneTime}"
+                    IsReadOnly="True"
+                    IsEnabled="False"
+                    Width="300"
+                    Margin="0,0,0,16" />
 
-            <TextBox x:Name="AccountEditPage_UsernameTextBox"
-                     x:Uid="AccountEditPage_UsernameTextBox"
-                     Text="{x:Bind ViewModel.Request.Username, Mode=TwoWay}"
-                     Width="300"
-                     Margin="0,0,0,16" />
+            <!-- Username -->
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+                <TextBox x:Name="AccountEditPage_UsernameTextBox"
+                        x:Uid="AccountEditPage_UsernameTextBox"
+                        GettingFocus="AccountEditPage_UsernameTextBox_GettingFocus"
+                        Text="{x:Bind ViewModel.Form.Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        Width="300" />
+                <TextBlock Text="{x:Bind ViewModel.Form.Errors, 
+                                Mode=OneWay, 
+                                Converter={StaticResource FirstError},
+                                ConverterParameter=Username}"
+                         Margin="0,8,0,16"
+                         Foreground="Red"/>
+            </StackPanel>
 
-            <Grid Width="300" Margin="0,0,0,16">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
+            <!-- Password -->
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+                <Grid Width="300">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
 
-                <PasswordBox x:Name="AccountEditPage_PasswordBox"
-                            x:Uid="AccountEditPage_PasswordBox"
-                            Password="{x:Bind ViewModel.Request.Password, Mode=TwoWay}"
-                            IsEnabled="{x:Bind ViewModel.IsPasswordEditEnabled, Mode=OneWay}"
-                            Width="240"/>
+                    <PasswordBox x:Name="AccountEditPage_PasswordBox"
+                               x:Uid="AccountEditPage_PasswordBox"
+                               GettingFocus="AccountEditPage_PasswordBox_GettingFocus"
+                               Password="{x:Bind ViewModel.Form.Password, Mode=TwoWay}"
+                               IsEnabled="{x:Bind ViewModel.IsPasswordEditEnabled, Mode=OneWay}"
+                               Width="240"/>
 
-                <Button Grid.Column="1"
-                        x:Name="EnablePasswordEditButton"
-                        Content="Edit"
-                        Command="{x:Bind ViewModel.EnablePasswordEditCommand}"
-                        Margin="8,0,0,0"/>
-            </Grid>
+                    <Button Grid.Column="1"
+                            x:Name="EnablePasswordEditButton"
+                            x:Uid="AccountEditPage_EnablePasswordEdit"
+                            Command="{x:Bind ViewModel.EnablePasswordEditCommand}"
+                            Margin="8,27,0,0"/>
+                </Grid>
+                <TextBlock Text="{x:Bind ViewModel.Form.Errors, 
+                                Mode=OneWay, 
+                                Converter={StaticResource FirstError},
+                                ConverterParameter=Password}"
+                         Margin="0,8,0,16"
+                         Foreground="Red"/>
+            </StackPanel>
 
-            <ComboBox x:Name="AccountEditPage_RoleComboBox"
-                      x:Uid="AccountEditPage_RoleComboBox"
-                      ItemsSource="{x:Bind ViewModel.Roles}"
-                      SelectedValue="{x:Bind ViewModel.Request.Role, Mode=TwoWay}"
-                      Width="300"
-                      Margin="0,0,0,16" />
+            <!-- Role -->
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+                <ComboBox x:Name="AccountEditPage_RoleComboBox"
+                         x:Uid="AccountEditPage_RoleComboBox"
+                         GettingFocus="AccountEditPage_RoleComboBox_GettingFocus"
+                         ItemsSource="{x:Bind ViewModel.Roles}"
+                         SelectedValue="{x:Bind ViewModel.Form.Role, Mode=TwoWay}"
+                         Width="300" />
+                <TextBlock Text="{x:Bind ViewModel.Form.Errors, 
+                                Mode=OneWay, 
+                                Converter={StaticResource FirstError},
+                                ConverterParameter=Role}"
+                         Margin="0,8,0,16"
+                         Foreground="Red"/>
+            </StackPanel>
 
-            <ComboBox x:Name="AccountEditPage_ZoneComboBox"
-                      x:Uid="AccountEditPage_ZoneComboBox"
-                      ItemsSource="{x:Bind ViewModel.Zones, Mode=OneWay}"
-                      DisplayMemberPath="Name"
-                      SelectedValuePath="ZoneId"
-                      SelectedValue="{x:Bind ViewModel.SelectedZoneId, Mode=TwoWay}"
-                      Width="300"
-                      Margin="0,0,0,16" />
+            <!-- Zone -->
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+                <ComboBox x:Name="AccountEditPage_ZoneComboBox"
+                         x:Uid="AccountEditPage_ZoneComboBox"
+                         GettingFocus="AccountEditPage_ZoneComboBox_GettingFocus"
+                         ItemsSource="{x:Bind ViewModel.Zones, Mode=OneWay}"
+                         DisplayMemberPath="Name"
+                         SelectedValuePath="ZoneId"
+                         SelectedValue="{x:Bind ViewModel.Form.ZoneId, Mode=TwoWay}"
+                         Width="300" />
+                <TextBlock Text="{x:Bind ViewModel.Form.Errors, 
+                                Mode=OneWay, 
+                                Converter={StaticResource FirstError},
+                                ConverterParameter=ZoneId}"
+                         Margin="0,8,0,16"
+                         Foreground="Red"/>
+            </StackPanel>
 
-            <ComboBox x:Name="AccountEditPage_TableComboBox"
-                      x:Uid="AccountEditPage_TableComboBox"
-                      ItemsSource="{x:Bind ViewModel.Tables, Mode=OneWay}"
-                      DisplayMemberPath="Number"
-                      SelectedValuePath="TableId"
-                      SelectedValue="{x:Bind ViewModel.Request.TableId, Mode=TwoWay}"
-                      IsEnabled="{x:Bind ViewModel.IsTableSelectionEnabled, Mode=OneWay}"
-                      Width="300" />
+            <!-- Table -->
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+                <ComboBox x:Name="AccountEditPage_TableComboBox"
+                         x:Uid="AccountEditPage_TableComboBox"
+                         GettingFocus="AccountEditPage_TableComboBox_GettingFocus"
+                         ItemsSource="{x:Bind ViewModel.Tables, Mode=OneWay}"
+                         DisplayMemberPath="Number"
+                         SelectedValuePath="TableId"
+                         SelectedValue="{x:Bind ViewModel.Form.TableId, Mode=TwoWay}"
+                         IsEnabled="{x:Bind ViewModel.IsTableSelectionEnabled, Mode=OneWay}"
+                         Width="300" />
+                <TextBlock Text="{x:Bind ViewModel.Form.Errors, 
+                                Mode=OneWay, 
+                                Converter={StaticResource FirstError},
+                                ConverterParameter=TableId}"
+                         Margin="0,8,0,16"
+                         Foreground="Red"/>
+            </StackPanel>
         </StackPanel>
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+        <!-- Buttons -->
+        <StackPanel Grid.Row="1" 
+                    Orientation="Horizontal" 
+                    HorizontalAlignment="Right"
+                    Margin="24">
             <Button x:Name="AdminAccountEditPage_EditButton"
                     x:Uid="AdminAccountEditPage_EditButton" 
                     Style="{StaticResource AccentButtonStyle}" 

--- a/BistroQ.Presentation/Views/AdminAccount/AdminAccountEditPage.xaml.cs
+++ b/BistroQ.Presentation/Views/AdminAccount/AdminAccountEditPage.xaml.cs
@@ -15,22 +15,12 @@ public sealed partial class AdminAccountEditPage : Page
         ViewModel = App.GetService<AdminAccountEditPageViewModel>();
         this.DataContext = ViewModel;
 
-        this.Loaded += AdminAccountEditPage_Loaded;
         ViewModel.NavigateBack += OnNavigateBack;
 
         this.Unloaded += (s, e) =>
         {
             ViewModel.NavigateBack -= OnNavigateBack;
         };
-    }
-
-    private async void AdminAccountEditPage_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
-    {
-        await ViewModel.LoadZonesAsync();
-        if (ViewModel.SelectedZoneId.HasValue)
-        {
-            await ViewModel.LoadTablesAsync(ViewModel.SelectedZoneId.Value);
-        }
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -52,5 +42,30 @@ public sealed partial class AdminAccountEditPage : Page
     private void OnNavigateBack(object sender, EventArgs e)
     {
         Frame.GoBack();
+    }
+
+    private void AccountEditPage_UsernameTextBox_GettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        ViewModel.Form.ResetError(nameof(ViewModel.Form.Username));
+    }
+
+    private void AccountEditPage_PasswordBox_GettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        ViewModel.Form.ResetError(nameof(ViewModel.Form.Password));
+    }
+
+    private void AccountEditPage_RoleComboBox_GettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        ViewModel.Form.ResetError(nameof(ViewModel.Form.Role));
+    }
+
+    private void AccountEditPage_ZoneComboBox_GettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        ViewModel.Form.ResetError(nameof(ViewModel.Form.ZoneId));
+    }
+
+    private void AccountEditPage_TableComboBox_GettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        ViewModel.Form.ResetError(nameof(ViewModel.Form.TableId));
     }
 }

--- a/BistroQ.Presentation/Views/AdminAccount/AdminAccountEditPage.xaml.cs
+++ b/BistroQ.Presentation/Views/AdminAccount/AdminAccountEditPage.xaml.cs
@@ -1,0 +1,56 @@
+﻿using BistroQ.Presentation.ViewModels.AdminAccount;
+using BistroQ.Presentation.ViewModels.Models;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace BistroQ.Presentation.Views.AdminAccount;
+
+public sealed partial class AdminAccountEditPage : Page
+{
+    public AdminAccountEditPageViewModel ViewModel { get; set; }
+
+    public AdminAccountEditPage()
+    {
+        InitializeComponent();
+        ViewModel = App.GetService<AdminAccountEditPageViewModel>();
+        this.DataContext = ViewModel;
+
+        this.Loaded += AdminAccountEditPage_Loaded;
+        ViewModel.NavigateBack += OnNavigateBack;
+
+        this.Unloaded += (s, e) =>
+        {
+            ViewModel.NavigateBack -= OnNavigateBack;
+        };
+    }
+
+    private async void AdminAccountEditPage_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        await ViewModel.LoadZonesAsync();
+        if (ViewModel.SelectedZoneId.HasValue)
+        {
+            await ViewModel.LoadTablesAsync(ViewModel.SelectedZoneId.Value);
+        }
+    }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        var accountDto = e.Parameter as AccountViewModel;
+        if (accountDto != null)
+        {
+            ViewModel.Account = accountDto;
+        }
+
+        base.OnNavigatedTo(e);
+    }
+
+    private void AdminAccountEditPage_CancelButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        Frame.GoBack();
+    }
+
+    private void OnNavigateBack(object sender, EventArgs e)
+    {
+        Frame.GoBack();
+    }
+}

--- a/BistroQ.Presentation/Views/AdminAccount/AdminAccountPage.xaml
+++ b/BistroQ.Presentation/Views/AdminAccount/AdminAccountPage.xaml
@@ -85,15 +85,16 @@
                     IsReadOnly="True"
                     Tag="Role" />
                 <controls:DataGridTextColumn 
+                    Binding="{Binding TableDisplay}" 
+                    Header="Table"
+                    IsReadOnly="True"
+                    MinWidth="220"
+                    Tag="TableId" />
+                <controls:DataGridTextColumn 
                     Binding="{Binding ZoneName}" 
                     Header="Zone"
                     IsReadOnly="True"
                     Tag="ZoneName" />
-                <controls:DataGridTextColumn 
-                    Binding="{Binding TableDisplay}" 
-                    Header="Table"
-                    IsReadOnly="True"
-                    Tag="TableId" />
             </controls:DataGrid.Columns>
         </controls:DataGrid>
 

--- a/BistroQ.Presentation/Views/AdminAccount/AdminAccountPage.xaml
+++ b/BistroQ.Presentation/Views/AdminAccount/AdminAccountPage.xaml
@@ -1,0 +1,102 @@
+﻿<Page
+    x:Class="BistroQ.Presentation.Views.AdminAccountPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls" 
+    xmlns:local="using:BistroQ.Presentation.Views.UserControls"
+    mc:Ignorable="d">
+
+    <Grid x:Name="ContentArea">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" HorizontalAlignment="Stretch">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <AutoSuggestBox PlaceholderText="Search accounts by username"
+                Text="{x:Bind ViewModel.State.SearchText, Mode=TwoWay}"
+                QueryIcon="Find"
+                QuerySubmitted="Control2_QuerySubmitted"
+                SuggestionChosen="Control2_SuggestionChosen"
+                Width="300"
+                HorizontalAlignment="Left"/>
+
+            <StackPanel x:Name="AdminAccountPage_Buttons" Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right">
+                <Button Style="{StaticResource AccentButtonStyle}" Command="{x:Bind ViewModel.AddCommand}" Width="120" Margin="0,0,8,0">
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon Glyph="&#xE710;" FontFamily="Segoe MDL2 Assets" />
+                            <TextBlock x:Uid="AdminAccount_DataGrid_AddNewButtonText" Text="Add New" Margin="8,0,0,0" />
+                        </StackPanel>
+                    </Button.Content>
+                </Button>
+                <Button Command="{x:Bind ViewModel.EditCommand}" Width="120" Margin="0,0,8,0">
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon Glyph="&#xE70F;" FontFamily="Segoe MDL2 Assets" />
+                            <TextBlock Text="Edit" Margin="8,0,0,0" />
+                        </StackPanel>
+                    </Button.Content>
+                </Button>
+                <Button Command="{x:Bind ViewModel.DeleteCommand}" Width="120" Margin="0,0,8,0">
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon Glyph="&#xE74D;" FontFamily="Segoe MDL2 Assets" />
+                            <TextBlock Text="Delete" Margin="8,0,0,0" />
+                        </StackPanel>
+                    </Button.Content>
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <controls:DataGrid
+            x:Name="AdminAccountDataGrid"
+            AutoGenerateColumns="False"
+            GridLinesVisibility="Horizontal"
+            ItemsSource="{x:Bind ViewModel.State.Source, Mode=OneWay}"
+            SelectedItem="{x:Bind ViewModel.State.SelectedAccount, Mode=TwoWay}"
+            Grid.Row="1"
+            Sorting="ViewModel_AdminAccountDataGrid_Sorting">
+            <controls:DataGrid.Resources>
+                <SolidColorBrush x:Key="DataGridColumnHeaderBackgroundColor" Color="Transparent" />
+            </controls:DataGrid.Resources>
+            <controls:DataGrid.Columns>
+                <controls:DataGridTextColumn 
+                    Binding="{Binding UserId}" 
+                    Header="User ID"
+                    IsReadOnly="True"
+                    Tag="UserId" />
+                <controls:DataGridTextColumn 
+                    Binding="{Binding Username}" 
+                    Header="Username"
+                    IsReadOnly="True"
+                    Tag="Username" />
+                <controls:DataGridTextColumn 
+                    Binding="{Binding Role}" 
+                    Header="Role"
+                    IsReadOnly="True"
+                    Tag="Role" />
+                <controls:DataGridTextColumn 
+                    Binding="{Binding ZoneName}" 
+                    Header="Zone"
+                    IsReadOnly="True"
+                    Tag="ZoneName" />
+                <controls:DataGridTextColumn 
+                    Binding="{Binding TableDisplay}" 
+                    Header="Table"
+                    IsReadOnly="True"
+                    Tag="TableId" />
+            </controls:DataGrid.Columns>
+        </controls:DataGrid>
+
+        <local:PaginationControl Grid.Row="2" Margin="0,0,0,24" />
+    </Grid>
+</Page>

--- a/BistroQ.Presentation/Views/AdminAccount/AdminAccountPage.xaml.cs
+++ b/BistroQ.Presentation/Views/AdminAccount/AdminAccountPage.xaml.cs
@@ -1,0 +1,44 @@
+﻿using BistroQ.Presentation.ViewModels;
+using CommunityToolkit.WinUI.UI.Controls;
+using Microsoft.UI.Xaml.Controls;
+
+namespace BistroQ.Presentation.Views;
+
+public sealed partial class AdminAccountPage : Page
+{
+    public AdminAccountViewModel ViewModel
+    {
+        get;
+    }
+
+    public AdminAccountPage()
+    {
+        ViewModel = App.GetService<AdminAccountViewModel>();
+        InitializeComponent();
+        this.Unloaded += (s, e) => ViewModel.Dispose();
+    }
+
+    private void Control2_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+    {
+        if (args.ChosenSuggestion != null)
+        {
+            ViewModel.State.SearchText = args.ChosenSuggestion.ToString();
+        }
+        else
+        {
+            ViewModel.State.SearchText = args.QueryText;
+        }
+
+        ViewModel.SearchCommand.Execute(null);
+    }
+
+    private void Control2_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+    {
+        sender.Text = args.SelectedItem.ToString();
+    }
+
+    private void ViewModel_AdminAccountDataGrid_Sorting(object? sender, DataGridColumnEventArgs e)
+    {
+        ViewModel.AdminAccountDataGrid_Sorting(sender, e);
+    }
+}

--- a/BistroQ.Presentation/Views/ShellPage.xaml
+++ b/BistroQ.Presentation/Views/ShellPage.xaml
@@ -71,6 +71,12 @@
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
 
+                <NavigationViewItem x:Uid="Shell_AdminAccount" Tag="Admin" helpers:NavigationHelper.NavigateTo="BistroQ.Presentation.ViewModels.AdminAccountViewModel">
+                    <NavigationViewItem.Icon>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE7FB;"/>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+
                 <NavigationViewItem x:Uid="Shell_ClientHomePage" Tag="Client" helpers:NavigationHelper.NavigateTo="BistroQ.Presentation.ViewModels.Client.HomePageViewModel">
                     <NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xED56;"/>

--- a/BistroQ.Presentation/Views/ShellPage.xaml
+++ b/BistroQ.Presentation/Views/ShellPage.xaml
@@ -48,32 +48,34 @@
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe7c3;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                
                 <NavigationViewItem x:Uid="Shell_AdminZone" Tag="Admin" helpers:NavigationHelper.NavigateTo="BistroQ.Presentation.ViewModels.AdminZoneViewModel">
                     <NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE71D;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+
                 <NavigationViewItem x:Uid="Shell_AdminTable" Tag="Admin" helpers:NavigationHelper.NavigateTo="BistroQ.Presentation.ViewModels.AdminTableViewModel">
                     <NavigationViewItem.Icon>
-                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE7FB;"/>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE977;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
 
                 <NavigationViewItem x:Uid="Shell_AdminCategory" Tag="Admin" helpers:NavigationHelper.NavigateTo="BistroQ.Presentation.ViewModels.AdminCategoryViewModel">
                     <NavigationViewItem.Icon>
-                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE7FB;"/>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8FD;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
 
                 <NavigationViewItem x:Uid="Shell_AdminProduct" Tag="Admin" helpers:NavigationHelper.NavigateTo="BistroQ.Presentation.ViewModels.AdminProductViewModel">
                     <NavigationViewItem.Icon>
-                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE7FB;"/>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE719;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
 
                 <NavigationViewItem x:Uid="Shell_AdminAccount" Tag="Admin" helpers:NavigationHelper.NavigateTo="BistroQ.Presentation.ViewModels.AdminAccountViewModel">
                     <NavigationViewItem.Icon>
-                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE7FB;"/>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE77B;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
 

--- a/BistroQ.Presentation/Views/UserControls/PaginationControl.xaml.cs
+++ b/BistroQ.Presentation/Views/UserControls/PaginationControl.xaml.cs
@@ -4,7 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System.Data;
+using System.Diagnostics;
 
 namespace BistroQ.Presentation.Views.UserControls;
 
@@ -52,7 +52,6 @@ public partial class PaginationControl : UserControl, IDisposable, IRecipient<Pa
         if (d is PaginationControl control)
         {
             control.UpdateCommandStates();
-            control.UpdatePagination((PaginationViewModel)e.NewValue);
         }
     }
 
@@ -64,17 +63,6 @@ public partial class PaginationControl : UserControl, IDisposable, IRecipient<Pa
         LastPageCommand.NotifyCanExecuteChanged();
     }
 
-    private void UpdatePagination(PaginationViewModel pagination)
-    {
-        var item = RowsPerPageSelection.Items
-            .Cast<ComboBoxItem>()
-            .FirstOrDefault(x => x.Content.ToString() == pagination.PageSize.ToString());
-        if (item != null)
-        {
-            RowsPerPageSelection.SelectedItem = item;
-        }
-    }
-
     private void RowsPerPageSelection_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (sender is ComboBox comboBox && comboBox.SelectedItem is ComboBoxItem item)
@@ -82,7 +70,7 @@ public partial class PaginationControl : UserControl, IDisposable, IRecipient<Pa
             if (int.TryParse(item.Content.ToString(), out int pageSize))
             {
                 _messenger.Send(new PageSizeChangedMessage(pageSize));
-                _messenger.Send(new CurrentPageChangedMessage(1));
+                Debug.WriteLine("ABC");
                 Pagination.CurrentPage = 1;
             }
         }
@@ -123,7 +111,6 @@ public partial class PaginationControl : UserControl, IDisposable, IRecipient<Pa
             CurrentPage = message.CurrentPage,
             TotalPages = message.TotalPages
         };
-        UpdateCommandStates();
     }
 
     public void Dispose()

--- a/BistroQ.Service/Data/AccountDataService.cs
+++ b/BistroQ.Service/Data/AccountDataService.cs
@@ -1,0 +1,76 @@
+﻿using AutoMapper;
+using BistroQ.Domain.Contracts.Services;
+using BistroQ.Domain.Dtos;
+using BistroQ.Domain.Dtos.Account;
+using BistroQ.Domain.Models.Entities;
+
+namespace BistroQ.Service.Data;
+
+public class AccountDataService : IAccountDataService
+{
+    private readonly IApiClient _apiClient;
+    private readonly IMapper _mapper;
+
+    public AccountDataService(IApiClient apiClient, IMapper mapper)
+    {
+        _apiClient = apiClient;
+        _mapper = mapper;
+    }
+
+    public async Task<ApiCollectionResponse<IEnumerable<Account>>> GetGridDataAsync(AccountCollectionQueryParams query = null)
+    {
+        var response = await _apiClient.GetCollectionAsync<IEnumerable<AccountResponse>>("/api/admin/account", query);
+        if (response.Success)
+        {
+            var accounts = _mapper.Map<IEnumerable<Account>>(response.Data);
+            return new ApiCollectionResponse<IEnumerable<Account>>
+                (accounts, response.TotalItems, response.CurrentPage, response.TotalPages);
+        }
+
+        throw new Exception("Failed to get accounts");
+    }
+
+    public async Task<Account> GetAccountByIdAsync(string userId)
+    {
+        var response = await _apiClient.GetAsync<AccountResponse>($"api/admin/account/{userId}", null);
+        if (response.Success)
+        {
+            return _mapper.Map<Account>(response.Data);
+        }
+
+        throw new Exception("Failed to get account");
+    }
+
+    public async Task<Account> CreateAccountAsync(CreateAccountRequest request)
+    {
+        var response = await _apiClient.PostAsync<AccountResponse>("api/admin/account", request);
+        if (response.Success)
+        {
+            return _mapper.Map<Account>(response.Data);
+        }
+
+        throw new Exception("Failed to create account");
+    }
+
+    public async Task<Account> UpdateAccountAsync(string userId, UpdateAccountRequest request)
+    {
+        var response = await _apiClient.PutAsync<AccountResponse>($"api/admin/account/{userId}", request);
+        if (response.Success)
+        {
+            return _mapper.Map<Account>(response.Data);
+        }
+
+        throw new Exception("Failed to update account");
+    }
+
+    public async Task<bool> DeleteAccountAsync(string userId)
+    {
+        var response = await _apiClient.DeleteAsync<object>($"api/admin/account/{userId}", null);
+        if (!response.Success)
+        {
+            throw new Exception(response.Message);
+        }
+
+        return true;
+    }
+}

--- a/BistroQ.Service/Data/AccountDataService.cs
+++ b/BistroQ.Service/Data/AccountDataService.cs
@@ -54,7 +54,7 @@ public class AccountDataService : IAccountDataService
 
     public async Task<Account> UpdateAccountAsync(string userId, UpdateAccountRequest request)
     {
-        var response = await _apiClient.PutAsync<AccountResponse>($"api/admin/account/{userId}", request);
+        var response = await _apiClient.PatchAsync<AccountResponse>($"api/admin/account/{userId}", request);
         if (response.Success)
         {
             return _mapper.Map<Account>(response.Data);


### PR DESCRIPTION
Updates:

- Added Account-related files: Pages, ViewModels, Services... for admin interface.
- Changed icon for nav bar.
- Integrated `CancellationTokenSource` within the `DialogService` to show only the first dialog and dismiss any subsequent ones.

Notes:

- Ensure you switch to the `feat/account-management` branch in the API repository.